### PR TITLE
1.0.9: Additional variables for cueTimeLeft, ability to use cue ID in actions, add cue property actions

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -42,6 +42,17 @@
 - Toggle Playlist Transition on Play
 - Transition on Play Off
 - Transition on Play On
+- Cue Scale
+- Cue Position
+- Cue Crop
+- Cue Rotation
+- Cue Hue
+- Cue Saturation
+- Cue Vibrance
+- Cue Brightness
+- Cue Contrast
+- Cue Opacity
+- Cue Volume
 - Resend OSC Feedback
 
 **Available Feedback**

--- a/HELP.md
+++ b/HELP.md
@@ -31,7 +31,9 @@
 - Goto 20
 - Goto 10
 - Play Selected Cue
+- Play cue with number
 - Play cue with name
+- Play cue with ID
 - Toggle Fullscreen
 - Fullscreen On
 - Fullscreen Off

--- a/HELP.md
+++ b/HELP.md
@@ -1,57 +1,61 @@
 ## Mitti
 
-In Mitti > Preferences... > OSC/UDP Controls, make sure "Enabled" is selected. Once enabled, this module sends OSC commands to port 51000 to the IP in the configuration settings.
-![Mitti](images/mitti.png?raw=true "Mitti")
+**Basic Configuration**
+
+- In Mitti > Preferences... > OSC/UDP Controls, make sure "Enabled" is selected.
+- In the configuration page for the Mitti module in Companion, enter the IP address of the computer running Mitti.
+
+**Enabling Button Variables & Feedback**
+
+- In Mitti > Preferences... > OSC/UDP Controls, select **Custom** from the **Feedback To** dropdown.
+- For **IP** enter the IP address for the computer running Companion.
+- For **Port** enter the port number that is present on the configuration page for the Mitti module in Companion. By default port 51001 is used.
+
+![Mitti](images/mitti.png?raw=true 'Mitti')
 
 **Available Actions**
 
-* Play
-* Toggle Play
-* Stop
-* Panic
-* Rewind
-* Jump to previous cue
-* Jump to next cue
-* Jump to specific cue (number)
-* Jump to selected cue
-* Jump to cue with name
-* Select previous cue
-* Select next cue
-* Goto 30
-* Goto 20
-* Goto 10
-* Play Selected Cue
-* Play cue with name
-* Toggle Fullscreen
-* Fullscreen On
-* Fullscreen Off
-* Toggle Playlist Loop
-* Playlist Loop On
-* Playlist Loop Off
-* Toggle Playlist Transition on Play
-* Transition on Play Off
-* Transition on Play On
-* Resend OSC Feedback
+- Play
+- Toggle Play
+- Stop
+- Panic
+- Rewind
+- Jump to previous cue
+- Jump to next cue
+- Jump to specific cue (number)
+- Jump to selected cue
+- Jump to cue with name
+- Select previous cue
+- Select next cue
+- Goto 30
+- Goto 20
+- Goto 10
+- Play Selected Cue
+- Play cue with name
+- Toggle Fullscreen
+- Fullscreen On
+- Fullscreen Off
+- Toggle Playlist Loop
+- Playlist Loop On
+- Playlist Loop Off
+- Toggle Playlist Transition on Play
+- Transition on Play Off
+- Transition on Play On
+- Resend OSC Feedback
 
 **Available Feedback**
 
-* Play/Pause Status
+- Play/Pause Status
 
 **Available Variables**
 
-* currentCueName
-* previousCueName
-* nextCueName
-* selectedCueName
-* playStatus
-* cueTimeLeft ***Time remaining for current cue (-HH:MM:SS)***
-* cueTimeLeft_h ***Time remaining for current cue (hours)***
-* cueTimeLeft_m ***Time remaining for current cue (minutes)***
-* cueTimeLeft_s ***Time remaining for current cue (minutes)***
-* currentCueTRT ***Total Runtime (TRT) of Current Cue***
-
-
-**Enabling Button Variables & Feedback**
-* In Mitti > Preferences... > OSC/UDP Controls, select "Custom" from the "Feedback To:" dropdown.
-* For "IP:" enter the IP address for the computer running Companion.
-* For "Port:" enter the port number that is present on the configuration page for the Mitti module in Companion. By default, it's 51001.
+- currentCueName
+- previousCueName
+- nextCueName
+- selectedCueName
+- playStatus
+- cueTimeLeft **_Time remaining for current cue (-HH:MM:SS)_**
+- cueTimeLeft_h **_Time remaining for current cue (hours)_**
+- cueTimeLeft_m **_Time remaining for current cue (minutes)_**
+- cueTimeLeft_s **_Time remaining for current cue (minutes)_**
+- currentCueTRT **_Total Runtime (TRT) of Current Cue_**

--- a/HELP.md
+++ b/HELP.md
@@ -31,9 +31,8 @@
 - Goto 20
 - Goto 10
 - Play Selected Cue
-- Play cue with number
+- Play cue with number / ID
 - Play cue with name
-- Play cue with ID
 - Toggle Fullscreen
 - Fullscreen On
 - Fullscreen Off

--- a/HELP.md
+++ b/HELP.md
@@ -39,13 +39,17 @@ In Mitti > Preferences... > OSC/UDP Controls, make sure "Enabled" is selected. O
 
 **Available Variables**
 
-* Current Cue Name
-* Previous Cue Name
-* Selected Cue Name
-* Next Cue Name
-* Time Left in Current Cue
-* Total Runtime (TRT) of Current Cue
-* Play/Pause Status
+* currentCueName
+* previousCueName
+* nextCueName
+* selectedCueName
+* playStatus
+* cueTimeLeft ***Time remaining for current cue (-HH:MM:SS)***
+* cueTimeLeft_h ***Time remaining for current cue (hours)***
+* cueTimeLeft_m ***Time remaining for current cue (minutes)***
+* cueTimeLeft_s ***Time remaining for current cue (minutes)***
+* currentCueTRT ***Total Runtime (TRT) of Current Cue***
+
 
 **Enabling Button Variables & Feedback**
 * In Mitti > Preferences... > OSC/UDP Controls, select "Custom" from the "Feedback To:" dropdown.

--- a/HELP.md
+++ b/HELP.md
@@ -22,7 +22,7 @@
 - Rewind
 - Jump to previous cue
 - Jump to next cue
-- Jump to specific cue (number)
+- Jump to specific cue
 - Jump to selected cue
 - Jump to cue with name
 - Select previous cue

--- a/mitti.js
+++ b/mitti.js
@@ -1072,7 +1072,7 @@ instance.prototype.actions = function (system) {
 			],
 		},
 		play_cue: {
-			label: 'Play Cue',
+			label: 'Play cue with number',
 			options: [
 				{
 					type: 'textinput',
@@ -1088,6 +1088,16 @@ instance.prototype.actions = function (system) {
 				{
 					type: 'textinput',
 					label: 'Cue Name',
+					id: 'string',
+				},
+			],
+		},
+		playCueWithCueID: {
+			label: 'Play cue with ID',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue ID',
 					id: 'string',
 				},
 			],
@@ -1477,6 +1487,15 @@ instance.prototype.action = function (action) {
 			self.sendArg(cmd, arg)
 			break
 
+		case 'playCueWithCueID':
+			let cueID = opt.string.toUpperCase().slice(0, 6)
+			arg = {
+				type: 's',
+				value: cueID,
+			}
+			cmd = '/mitti/playCueWithCueID'
+			self.sendArg(cmd, arg)
+			break
 		case 'fullscreenOn':
 			cmd = '/mitti/fullscreenOn'
 			self.sendNoArg(cmd)

--- a/mitti.js
+++ b/mitti.js
@@ -1356,6 +1356,229 @@ instance.prototype.actions = function (system) {
 				},
 			],
 		},
+		scale: {
+			label: 'Cue Scale',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number or ID',
+					id: 'cuenumber',
+					default: 'current',
+				},
+				{
+					type: 'number',
+					label: 'Scale (%)',
+					id: 'value',
+					default: 0,
+					min: 0,
+					max: 200,
+				},
+			],
+		},
+		position: {
+			label: 'Cue Position',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number or ID',
+					id: 'cuenumber',
+					default: 'current',
+				},
+				{
+					type: 'textinput',
+					label: 'Position X (pixels, optional)',
+					id: 'valueX',
+				},
+				{
+					type: 'textinput',
+					label: 'Position Y (pixels, optional)',
+					id: 'valueY',
+				},
+			],
+		},
+		crop: {
+			label: 'Cue Crop',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number or ID',
+					id: 'cuenumber',
+					default: 'current',
+				},
+				{
+					type: 'textinput',
+					label: 'Crop Left (pixels, optional)',
+					id: 'valueLeft',
+				},
+				{
+					type: 'textinput',
+					label: 'Crop Right (pixels, optional)',
+					id: 'valueRight',
+				},
+				{
+					type: 'textinput',
+					label: 'Crop Top (pixels, optional)',
+					id: 'valueTop',
+				},
+				{
+					type: 'textinput',
+					label: 'Crop Bottom (pixels, optional)',
+					id: 'valueBottom',
+				},
+			],
+		},
+		rotation: {
+			label: 'Cue Rotation',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number or ID',
+					id: 'cuenumber',
+					default: 'current',
+				},
+				{
+					type: 'number',
+					label: 'Degrees (°)',
+					id: 'value',
+					default: 0,
+					min: -180,
+					max: 180,
+				},
+			],
+		},
+		hue: {
+			label: 'Cue Hue',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number or ID',
+					id: 'cuenumber',
+					default: 'current',
+				},
+				{
+					type: 'number',
+					label: 'Degrees (°)',
+					id: 'value',
+					default: 0,
+					min: -180,
+					max: 180,
+				},
+			],
+		},
+		saturation: {
+			label: 'Cue Saturation',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number or ID',
+					id: 'cuenumber',
+					default: 'current',
+				},
+				{
+					type: 'number',
+					label: 'Saturation (%)',
+					id: 'value',
+					default: 0,
+					min: -100,
+					max: 100,
+				},
+			],
+		},
+		vibrance: {
+			label: 'Cue Vibrance',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number or ID',
+					id: 'cuenumber',
+					default: 'current',
+				},
+				{
+					type: 'number',
+					label: 'Vibrance (%)',
+					id: 'value',
+					default: 0,
+					min: -100,
+					max: 100,
+				},
+			],
+		},
+		brightness: {
+			label: 'Cue Brightness',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number or ID',
+					id: 'cuenumber',
+					default: 'current',
+				},
+				{
+					type: 'number',
+					label: 'Brightness (%)',
+					id: 'value',
+					default: 0,
+					min: -100,
+					max: 100,
+				},
+			],
+		},
+		contrast: {
+			label: 'Cue Brightness',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number or ID',
+					id: 'cuenumber',
+					default: 'current',
+				},
+				{
+					type: 'number',
+					label: 'Contrast (%)',
+					id: 'value',
+					default: 0,
+					min: -100,
+					max: 100,
+				},
+			],
+		},
+		opacity: {
+			label: 'Cue Opacity',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number or ID',
+					id: 'cuenumber',
+					default: 'current',
+				},
+				{
+					type: 'number',
+					label: 'Opacity (%)',
+					id: 'value',
+					default: 100,
+					min: 0,
+					max: 100,
+				},
+			],
+		},
+		volume: {
+			label: 'Cue Volume',
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number or ID',
+					id: 'cuenumber',
+					default: 'current',
+				},
+				{
+					type: 'number',
+					label: 'Volume (db, -60 to 6)',
+					id: 'value',
+					default: 0,
+					min: -60,
+					max: 6,
+				},
+			],
+		},
 	})
 }
 
@@ -1661,6 +1884,130 @@ instance.prototype.action = function (action) {
 		case 'videoFxOff':
 			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/videoFxOff'
 			self.sendNoArg(cmd)
+			break
+		case 'scale':
+			arg = {
+				type: 's',
+				value: opt.value,
+			}
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/scaleAsPercent'
+			self.sendArg(cmd, arg)
+			break
+		case 'position':
+			if (opt.valueX) {
+				arg = {
+					type: 's',
+					value: opt.valueX,
+				}
+				cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/posXAsPixels'
+				self.sendArg(cmd, arg)
+			}
+			if (opt.valueY) {
+				arg = {
+					type: 's',
+					value: opt.valueY,
+				}
+				cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/posYAsPixels'
+				self.sendArg(cmd, arg)
+			}
+			break
+		case 'crop':
+			if (opt.valueLeft) {
+				arg = {
+					type: 's',
+					value: opt.valueLeft,
+				}
+				cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/cropLeftAsPixels'
+				self.sendArg(cmd, arg)
+			}
+			if (opt.valueRight) {
+				arg = {
+					type: 's',
+					value: opt.valueRight,
+				}
+				cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/cropRightAsPixels'
+				self.sendArg(cmd, arg)
+			}
+			if (opt.valueTop) {
+				arg = {
+					type: 's',
+					value: opt.valueTop,
+				}
+				cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/cropTopAsPixels'
+				self.sendArg(cmd, arg)
+			}
+			if (opt.valueBottom) {
+				arg = {
+					type: 's',
+					value: opt.valueBottom,
+				}
+				cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/cropBottomAsPixels'
+				self.sendArg(cmd, arg)
+			}
+			break
+		case 'rotation':
+			arg = {
+				type: 's',
+				value: opt.value,
+			}
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/rotateAsDegrees'
+			self.sendArg(cmd, arg)
+			break
+		case 'hue':
+			arg = {
+				type: 's',
+				value: opt.value,
+			}
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/hueAsDegrees'
+			self.sendArg(cmd, arg)
+			break
+		case 'saturation':
+			arg = {
+				type: 's',
+				value: opt.value,
+			}
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/saturationAsPercent'
+			self.sendArg(cmd, arg)
+			break
+		case 'vibrance':
+			arg = {
+				type: 's',
+				value: opt.value,
+			}
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/vibranceAsPercent'
+			self.sendArg(cmd, arg)
+			break
+		case 'brightness':
+			arg = {
+				type: 's',
+				value: opt.value,
+			}
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/brightnessAsPercent'
+			self.sendArg(cmd, arg)
+			break
+		case 'contrast':
+			arg = {
+				type: 's',
+				value: opt.value,
+			}
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/contrastAsPercent'
+			self.sendArg(cmd, arg)
+			break
+		case 'opacity':
+			arg = {
+				type: 's',
+				value: opt.value,
+			}
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/opacityAsPercent'
+			self.sendArg(cmd, arg)
+			break
+		case 'volume':
+			arg = {
+				type: 's',
+				value: parseFloat(opt.value),
+			}
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/volumeAsDecibels'
+			self.sendArg(cmd, arg)
 			break
 	}
 }

--- a/mitti.js
+++ b/mitti.js
@@ -1044,7 +1044,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1065,18 +1065,18 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
 			],
 		},
 		play_cue: {
-			label: 'Play cue with number',
+			label: 'Play cue with number / ID',
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1092,22 +1092,12 @@ instance.prototype.actions = function (system) {
 				},
 			],
 		},
-		playCueWithCueID: {
-			label: 'Play cue with ID',
-			options: [
-				{
-					type: 'textinput',
-					label: 'Cue ID',
-					id: 'string',
-				},
-			],
-		},
 		audioOn: {
 			label: 'Audio On',
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1118,7 +1108,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1129,7 +1119,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1140,7 +1130,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1151,7 +1141,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1162,7 +1152,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1173,7 +1163,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1184,7 +1174,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1195,7 +1185,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1206,7 +1196,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1217,7 +1207,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1228,7 +1218,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1239,7 +1229,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1250,7 +1240,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1261,7 +1251,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1272,7 +1262,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1283,7 +1273,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1294,7 +1284,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1305,7 +1295,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1316,7 +1306,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1327,7 +1317,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1338,7 +1328,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1349,7 +1339,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1360,7 +1350,7 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'textinput',
-					label: 'Cue number',
+					label: 'Cue number or ID',
 					id: 'cuenumber',
 					default: 'current',
 				},
@@ -1379,6 +1369,13 @@ instance.prototype.sendArg = function (str, str2) {
 	var self = this
 	self.system.emit('osc_send', self.config.host, 51000, str, [str2])
 	debug('Command =', str, str2)
+}
+
+instance.prototype.conformCueID = function (cueID) {
+	if (!cueID.match(/^(current|previous|next)$/)) {
+		cueID = cueID.toUpperCase().slice(0, 6)
+	}
+	return cueID
 }
 
 instance.prototype.action = function (action) {
@@ -1464,17 +1461,17 @@ instance.prototype.action = function (action) {
 			break
 
 		case 'jump_cue':
-			cmd = '/mitti/' + opt.cuenumber + '/jump'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/jump'
 			self.sendNoArg(cmd)
 			break
 
 		case 'select_cue':
-			cmd = '/mitti/' + opt.cuenumber + '/select'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/select'
 			self.sendNoArg(cmd)
 			break
 
 		case 'play_cue':
-			cmd = '/mitti/' + opt.cuenumber + '/play'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/play'
 			self.sendNoArg(cmd)
 			break
 
@@ -1487,15 +1484,6 @@ instance.prototype.action = function (action) {
 			self.sendArg(cmd, arg)
 			break
 
-		case 'playCueWithCueID':
-			let cueID = opt.string.toUpperCase().slice(0, 6)
-			arg = {
-				type: 's',
-				value: cueID,
-			}
-			cmd = '/mitti/playCueWithCueID'
-			self.sendArg(cmd, arg)
-			break
 		case 'fullscreenOn':
 			cmd = '/mitti/fullscreenOn'
 			self.sendNoArg(cmd)
@@ -1556,122 +1544,122 @@ instance.prototype.action = function (action) {
 			break
 
 		case 'toggleAudio':
-			cmd = '/mitti/' + opt.cuenumber + '/toggleAudio'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/toggleAudio'
 			self.sendNoArg(cmd)
 			break
 
 		case 'audioOn':
-			cmd = '/mitti/' + opt.cuenumber + '/audioOn'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/audioOn'
 			self.sendNoArg(cmd)
 			break
 
 		case 'audioOff':
-			cmd = '/mitti/' + opt.cuenumber + '/audioOff'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/audioOff'
 			self.sendNoArg(cmd)
 			break
 
 		case 'toggleFadeIn':
-			cmd = '/mitti/' + opt.cuenumber + '/toggleFadeIn'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/toggleFadeIn'
 			self.sendNoArg(cmd)
 			break
 
 		case 'fadeInOn':
-			cmd = '/mitti/' + opt.cuenumber + '/fadeInOn'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/fadeInOn'
 			self.sendNoArg(cmd)
 			break
 
 		case 'fadeInOff':
-			cmd = '/mitti/' + opt.cuenumber + '/fadeInOff'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/fadeInOff'
 			self.sendNoArg(cmd)
 			break
 
 		case 'toggleFadeOut':
-			cmd = '/mitti/' + opt.cuenumber + '/toggleFadeOut'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/toggleFadeOut'
 			self.sendNoArg(cmd)
 			break
 
 		case 'fadeOutOn':
-			cmd = '/mitti/' + opt.cuenumber + '/fadeOutOn'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/fadeOutOn'
 			self.sendNoArg(cmd)
 			break
 
 		case 'fadeOutOff':
-			cmd = '/mitti/' + opt.cuenumber + '/fadeOutOff'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/fadeOutOff'
 			self.sendNoArg(cmd)
 			break
 
 		case 'toggleLoop':
-			cmd = '/mitti/' + opt.cuenumber + '/toggleLoop'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/toggleLoop'
 			self.sendNoArg(cmd)
 			break
 
 		case 'loopOn':
-			cmd = '/mitti/' + opt.cuenumber + '/loopOn'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/loopOn'
 			self.sendNoArg(cmd)
 			break
 
 		case 'loopOff':
-			cmd = '/mitti/' + opt.cuenumber + '/loopOff'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/loopOff'
 			self.sendNoArg(cmd)
 			break
 
 		case 'togglePauseAtBeginning':
-			cmd = '/mitti/' + opt.cuenumber + '/togglePauseAtBeginning'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/togglePauseAtBeginning'
 			self.sendNoArg(cmd)
 			break
 
 		case 'pauseAtBeginningOn':
-			cmd = '/mitti/' + opt.cuenumber + '/pauseAtBeginningOn'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/pauseAtBeginningOn'
 			self.sendNoArg(cmd)
 			break
 
 		case 'pauseAtBeginningOff':
-			cmd = '/mitti/' + opt.cuenumber + '/pauseAtBeginningOff'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/pauseAtBeginningOff'
 			self.sendNoArg(cmd)
 			break
 
 		case 'togglePauseAtEnd':
-			cmd = '/mitti/' + opt.cuenumber + '/togglePauseAtEnd'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/togglePauseAtEnd'
 			self.sendNoArg(cmd)
 			break
 
 		case 'pauseAtEndOn':
-			cmd = '/mitti/' + opt.cuenumber + '/pauseAtEndOn'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/pauseAtEndOn'
 			self.sendNoArg(cmd)
 			break
 
 		case 'pauseAtEndOff':
-			cmd = '/mitti/' + opt.cuenumber + '/pauseAtEndOff'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/pauseAtEndOff'
 			self.sendNoArg(cmd)
 			break
 
 		case 'toggleTransition':
-			cmd = '/mitti/' + opt.cuenumber + '/toggleTransition'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/toggleTransition'
 			self.sendNoArg(cmd)
 			break
 
 		case 'transitionOn':
-			cmd = '/mitti/' + opt.cuenumber + '/transitionOn'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/transitionOn'
 			self.sendNoArg(cmd)
 			break
 
 		case 'transitionOff':
-			cmd = '/mitti/' + opt.cuenumber + '/transitionOff'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/transitionOff'
 			self.sendNoArg(cmd)
 			break
 
 		case 'toggleVideoFx':
-			cmd = '/mitti/' + opt.cuenumber + '/toggleVideoFx'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/toggleVideoFx'
 			self.sendNoArg(cmd)
 			break
 
 		case 'videoFxOn':
-			cmd = '/mitti/' + opt.cuenumber + '/videoFxOn'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/videoFxOn'
 			self.sendNoArg(cmd)
 			break
 
 		case 'videoFxOff':
-			cmd = '/mitti/' + opt.cuenumber + '/videoFxOff'
+			cmd = '/mitti/' + self.conformCueID(opt.cuenumber) + '/videoFxOff'
 			self.sendNoArg(cmd)
 			break
 	}

--- a/mitti.js
+++ b/mitti.js
@@ -1,48 +1,48 @@
-var instance_skel = require('../../instance_skel');
-var OSC = require('osc');
-var debug;
-var log;
+var instance_skel = require('../../instance_skel')
+var OSC = require('osc')
+var debug
+var log
 
 function instance(system, id, config) {
-	var self = this;
+	var self = this
 	// super-constructor
-	instance_skel.apply(this, arguments);
-	self.actions(); // export actions
+	instance_skel.apply(this, arguments)
+	self.actions() // export actions
 
-	return self;
+	return self
 }
 
-instance.GetUpgradeScripts = function() {
+instance.GetUpgradeScripts = function () {
 	return [
 		instance_skel.CreateConvertToBooleanFeedbackUpgradeScript({
-			'playStatus': true,
+			playStatus: true,
 		}),
 	]
 }
 
-instance.prototype.updateConfig = function(config) {
-	var self = this;
-	self.config = config;
-	self.init_presets();
-	self.init_variables();
-	self.init_feedbacks();
-	self.init_osc();
-};
+instance.prototype.updateConfig = function (config) {
+	var self = this
+	self.config = config
+	self.init_presets()
+	self.init_variables()
+	self.init_feedbacks()
+	self.init_osc()
+}
 
-instance.prototype.init = function() {
-	var self = this;
-	self.status(self.STATE_OK); // status ok!
-	self.init_presets();
-	self.init_variables();
-	self.init_feedbacks();
-	self.init_osc();
-	debug = self.debug;
-	log = self.log;
-};
+instance.prototype.init = function () {
+	var self = this
+	self.status(self.STATE_OK) // status ok!
+	self.init_presets()
+	self.init_variables()
+	self.init_feedbacks()
+	self.init_osc()
+	debug = self.debug
+	log = self.log
+}
 
 // Return config fields for web config
 instance.prototype.config_fields = function () {
-	var self = this;
+	var self = this
 	return [
 		{
 			type: 'textinput',
@@ -50,7 +50,7 @@ instance.prototype.config_fields = function () {
 			label: 'Target IP',
 			tooltip: 'The IP of the computer running Mitti',
 			width: 6,
-			regex: self.REGEX_IP
+			regex: self.REGEX_IP,
 		},
 		{
 			type: 'textinput',
@@ -58,24 +58,23 @@ instance.prototype.config_fields = function () {
 			label: 'Feedback Port',
 			width: 5,
 			tooltip: 'The port designated for Feedback in the OSC/UDP Controls tab in Mitti',
-			default: 51001
-		}
+			default: 51001,
+		},
 	]
-};
+}
 
 // When module gets deleted
-instance.prototype.destroy = function() {
-	var self = this;
+instance.prototype.destroy = function () {
+	var self = this
 	if (self.listener) {
-		self.listener.close();
+		self.listener.close()
 	}
-	debug("destroy", self.id);
-};
+	debug('destroy', self.id)
+}
 
 instance.prototype.init_presets = function () {
-	var self = this;
+	var self = this
 	var presets = [
-
 		{
 			category: 'Playlist',
 			label: 'Play',
@@ -86,13 +85,13 @@ instance.prototype.init_presets = function () {
 				pngalignment: 'center:center',
 				size: '18',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,0),
+				bgcolor: self.rgb(0, 0, 0),
 			},
 			actions: [
 				{
 					action: 'play',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -104,13 +103,13 @@ instance.prototype.init_presets = function () {
 				pngalignment: 'center:center',
 				size: '18',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,0),
+				bgcolor: self.rgb(0, 0, 0),
 			},
 			actions: [
 				{
 					action: 'toggle_play',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -119,14 +118,14 @@ instance.prototype.init_presets = function () {
 				style: 'text',
 				text: 'Play\\nSelected',
 				size: '14',
-				color: self.rgb(0,0,0),
-				bgcolor: self.rgb(0,255,0)
+				color: self.rgb(0, 0, 0),
+				bgcolor: self.rgb(0, 255, 0),
 			},
 			actions: [
 				{
 					action: 'play_select',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -136,14 +135,14 @@ instance.prototype.init_presets = function () {
 				text: 'Pause',
 				size: '14',
 				//color: '16777215',
-				color: self.rgb(0,0,0),
-				bgcolor: self.rgb(255,255,0)
+				color: self.rgb(0, 0, 0),
+				bgcolor: self.rgb(255, 255, 0),
 			},
 			actions: [
 				{
 					action: 'stop',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -153,13 +152,13 @@ instance.prototype.init_presets = function () {
 				text: 'Panic',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(255,0,0)
+				bgcolor: self.rgb(255, 0, 0),
 			},
 			actions: [
 				{
 					action: 'panic',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -169,13 +168,13 @@ instance.prototype.init_presets = function () {
 				text: 'Rewind',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'rewind',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -185,13 +184,13 @@ instance.prototype.init_presets = function () {
 				text: 'Jump\\nPrevious',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'jump_prev',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -201,13 +200,13 @@ instance.prototype.init_presets = function () {
 				text: 'Jump\\nNext',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'jump_next',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -217,13 +216,13 @@ instance.prototype.init_presets = function () {
 				text: 'Jump\\nSelected',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'jump_selected',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -233,13 +232,13 @@ instance.prototype.init_presets = function () {
 				text: 'Select\\nPrevious',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'select_prev',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -249,13 +248,13 @@ instance.prototype.init_presets = function () {
 				text: 'Select\\nNext',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'select_next',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -265,13 +264,13 @@ instance.prototype.init_presets = function () {
 				text: 'Goto\\n30',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'goto_30',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -281,13 +280,13 @@ instance.prototype.init_presets = function () {
 				text: 'Goto\\n20',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'goto_20',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -297,13 +296,13 @@ instance.prototype.init_presets = function () {
 				text: 'Goto\\n10',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'goto_10',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -313,13 +312,13 @@ instance.prototype.init_presets = function () {
 				text: 'Toggle\\nFullscreen',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'fullscreenToggle',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -329,13 +328,13 @@ instance.prototype.init_presets = function () {
 				text: 'Fullscreen\\nOn',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'fullscreenOn',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -345,13 +344,13 @@ instance.prototype.init_presets = function () {
 				text: 'Fullscreen\\nOff',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'fullscreenOff',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -361,13 +360,13 @@ instance.prototype.init_presets = function () {
 				text: 'Toggle\\nPlaylist\\nLoop',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'plLoopToggle',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -377,13 +376,13 @@ instance.prototype.init_presets = function () {
 				text: 'Playlist\\nLoop\\nOn',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'plLoopOn',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -393,13 +392,13 @@ instance.prototype.init_presets = function () {
 				text: 'Playlist\\nLoop\\nOff',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'plLoopOff',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -409,13 +408,13 @@ instance.prototype.init_presets = function () {
 				text: 'Toggle\\nTransition',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'plTransToggle',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -425,13 +424,13 @@ instance.prototype.init_presets = function () {
 				text: 'Playlist\\nTransition\\nOff',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'plTransOff',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Playlist',
@@ -441,13 +440,13 @@ instance.prototype.init_presets = function () {
 				text: 'Playlist\\nTransition\\nOn',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'plTransOn',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -456,17 +455,17 @@ instance.prototype.init_presets = function () {
 				style: 'text',
 				text: 'Play\\nCue\\n(Number)',
 				size: '14',
-				color: self.rgb(0,0,0),
-				bgcolor: self.rgb(0,255,0)
+				color: self.rgb(0, 0, 0),
+				bgcolor: self.rgb(0, 255, 0),
 			},
 			actions: [
 				{
 					action: 'play_cue',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -475,21 +474,21 @@ instance.prototype.init_presets = function () {
 				style: 'text',
 				text: 'Play\\nCue\\n(Name)',
 				size: '14',
-				color: self.rgb(0,0,0),
-				bgcolor: self.rgb(0,255,0)
+				color: self.rgb(0, 0, 0),
+				bgcolor: self.rgb(0, 255, 0),
 			},
 			actions: [
 				{
 					action: 'jumpCueName',
 					options: {
 						string: '',
-					}
+					},
 				},
 				{
 					action: 'play',
 					delay: '100',
-				}
-			]
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -498,17 +497,17 @@ instance.prototype.init_presets = function () {
 				style: 'text',
 				text: 'Jump\\nCue\\n(Name)',
 				size: '14',
-				color: self.rgb(255,255,255),
-				bgcolor: self.rgb(0,0,100)
+				color: self.rgb(255, 255, 255),
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'jumpCueName',
 					options: {
 						string: '',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -518,17 +517,17 @@ instance.prototype.init_presets = function () {
 				text: 'Jump\\nCue\\n(Number)',
 				size: '14',
 				//color: '16777215',
-				color: self.rgb(255,255,255),
-				bgcolor: self.rgb(0,0,100)
+				color: self.rgb(255, 255, 255),
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'jump_cue',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -538,17 +537,17 @@ instance.prototype.init_presets = function () {
 				text: 'Select\\nCue\\n(Number)',
 				size: '14',
 				//color: '16777215',
-				color: self.rgb(255,255,255),
-				bgcolor: self.rgb(0,0,100)
+				color: self.rgb(255, 255, 255),
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'select_cue',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -558,16 +557,16 @@ instance.prototype.init_presets = function () {
 				text: 'Toggle\\nFade\\nIn',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'toggleFadeIn',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -577,16 +576,16 @@ instance.prototype.init_presets = function () {
 				text: 'Fade\\nIn\\nOn',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'fadeInOn',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -596,16 +595,16 @@ instance.prototype.init_presets = function () {
 				text: 'Fade\\nIn\\nOff',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'fadeInOff',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -615,16 +614,16 @@ instance.prototype.init_presets = function () {
 				text: 'Toggle\\nFade\\nOut',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'toggleFadeOut',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -634,16 +633,16 @@ instance.prototype.init_presets = function () {
 				text: 'Fade\\nOut\\nOn',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'fadeOutOn',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -653,16 +652,16 @@ instance.prototype.init_presets = function () {
 				text: 'Fade\\nOut\\nOff',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'fadeOutOff',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -672,16 +671,16 @@ instance.prototype.init_presets = function () {
 				text: 'Toggle\\nAudio',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'toggleAudio',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -691,16 +690,16 @@ instance.prototype.init_presets = function () {
 				text: 'Audio\\nOn',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'audioOn',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -710,16 +709,16 @@ instance.prototype.init_presets = function () {
 				text: 'Audio\\nOff',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'audioOff',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -729,16 +728,16 @@ instance.prototype.init_presets = function () {
 				text: 'Toggle\\nLoop',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'toggleLoop',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -748,16 +747,16 @@ instance.prototype.init_presets = function () {
 				text: 'Loop\\nOn',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'loopOn',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -767,16 +766,16 @@ instance.prototype.init_presets = function () {
 				text: 'Loop\\nOff',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'loopOff',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -786,16 +785,16 @@ instance.prototype.init_presets = function () {
 				text: 'Toggle\\nPause\\nBeginning',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'togglePauseAtBeginning',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -805,16 +804,16 @@ instance.prototype.init_presets = function () {
 				text: 'Pause\\nBeginning\\nOn',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'pauseAtBeginningOn',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -824,16 +823,16 @@ instance.prototype.init_presets = function () {
 				text: 'Pause\\nBeginning\\nOff',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'pauseAtBeginningOff',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -843,16 +842,16 @@ instance.prototype.init_presets = function () {
 				text: 'Toggle\\nPause\\nEnd',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'togglePauseAtEnd',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -862,16 +861,16 @@ instance.prototype.init_presets = function () {
 				text: 'Pause\\nEnd\\nOn',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'pauseAtEndOn',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -881,16 +880,16 @@ instance.prototype.init_presets = function () {
 				text: 'Pause\\nEnd\\nOff',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'pauseAtEndOff',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -900,16 +899,16 @@ instance.prototype.init_presets = function () {
 				text: 'Toggle\\nTransition',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'toggleTransition',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -919,16 +918,16 @@ instance.prototype.init_presets = function () {
 				text: 'Transition\\nOn',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'transitionOn',
 					options: {
 						cuenumber: 'current',
-					}
-				}
-			]
+					},
+				},
+			],
 		},
 		{
 			category: 'Cue',
@@ -938,741 +937,793 @@ instance.prototype.init_presets = function () {
 				text: 'Transition\\nOff',
 				size: '14',
 				color: '16777215',
-				bgcolor: self.rgb(0,0,100)
+				bgcolor: self.rgb(0, 0, 100),
 			},
 			actions: [
 				{
 					action: 'transitionOff',
 					options: {
 						cuenumber: 'current',
-
-					}
-				}
-			]
+					},
+				},
+			],
 		},
+		{
+			category: 'Cue',
+			label: 'Toggle VideoFx',
+			bank: {
+				style: 'text',
+				text: 'Toggle\\nVideoFx',
+				size: '14',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 100),
+			},
+			actions: [
 				{
-					category: 'Cue',
-					label: 'Toggle VideoFx',
-					bank: {
-						style: 'text',
-						text: 'Toggle\\nVideoFx',
-						size: '14',
-						color: '16777215',
-						bgcolor: self.rgb(0,0,100)
+					action: 'toggleVideoFx',
+					options: {
+						cuenumber: 'current',
 					},
-					actions: [
-						{
-							action: 'toggleVideoFx',
-							options: {
-								cuenumber: 'current',
-							}
-						}
-					]
 				},
+			],
+		},
+		{
+			category: 'Cue',
+			label: 'VideoFx On',
+			bank: {
+				style: 'text',
+				text: 'VideoFx\\nOn',
+				size: '14',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 100),
+			},
+			actions: [
 				{
-					category: 'Cue',
-					label: 'VideoFx On',
-					bank: {
-						style: 'text',
-						text: 'VideoFx\\nOn',
-						size: '14',
-						color: '16777215',
-						bgcolor: self.rgb(0,0,100)
+					action: 'videoFxOn',
+					options: {
+						cuenumber: 'current',
 					},
-					actions: [
-						{
-							action: 'videoFxOn',
-							options: {
-								cuenumber: 'current',
-							}
-						}
-					]
 				},
+			],
+		},
+		{
+			category: 'Cue',
+			label: 'VideoFx Off',
+			bank: {
+				style: 'text',
+				text: 'VideoFx\\nOff',
+				size: '14',
+				color: '16777215',
+				bgcolor: self.rgb(0, 0, 100),
+			},
+			actions: [
 				{
-					category: 'Cue',
-					label: 'VideoFx Off',
-					bank: {
-						style: 'text',
-						text: 'VideoFx\\nOff',
-						size: '14',
-						color: '16777215',
-						bgcolor: self.rgb(0,0,100)
+					action: 'videoFxOff',
+					options: {
+						cuenumber: 'current',
 					},
-					actions: [
-						{
-							action: 'videoFxOff',
-							options: {
-								cuenumber: 'current',
-							}
-						}
-					]
 				},
-		];
+			],
+		},
+	]
 
-		self.setPresetDefinitions(presets);
+	self.setPresetDefinitions(presets)
 }
 
-
-
-instance.prototype.actions = function(system) {
-	var self = this;
+instance.prototype.actions = function (system) {
+	var self = this
 
 	self.system.emit('instance_actions', self.id, {
-		'play':               { label: 'Play' },
-		'toggle_play':        { label: 'Pause / Resume' },
-		'stop':               { label: 'Pause' },
-		'panic':              { label: 'Panic' },
-		'rewind':             { label: 'Rewind' },
-		'jump_prev':          { label: 'Jump to previous cue' },
-		'jump_next':          { label: 'Jump to next cue' },
-		'jump_selected':      { label: 'Jump to selected cue' },
-		'select_prev':        { label: 'Select previous cue' },
-		'select_next':        { label: 'Select next cue' },
-		'goto_30':            { label: 'Goto 30'},
-		'goto_20':            { label: 'Goto 20'},
-		'goto_10':            { label: 'Goto 10'},
-		'play_select':        { label: 'Play Selected Cue'},
-		'fullscreenToggle':   { label: 'Toggle Fullscreen'},
-		'fullscreenOn':       { label: 'Fullscreen On'},
-		'fullscreenOff':      { label: 'Fullscreen Off'},
-		'plLoopToggle':       { label: 'Toggle Playlist Loop'},
-		'plLoopOn':           { label: 'Playlist Loop On'},
-		'plLoopOff':          { label: 'Playlist Loop Off'},
-		'plTransToggle':      { label: 'Toggle Playlist Transition on Play'},
-		'plTransOff':         { label: 'Transition on Play Off'},
-		'plTransOn':          { label: 'Transition on Play On'},
-		'resendOSCFeedback':  { label: 'Resend OSC feedback'},
-		'jump_cue':     {
+		play: { label: 'Play' },
+		toggle_play: { label: 'Pause / Resume' },
+		stop: { label: 'Pause' },
+		panic: { label: 'Panic' },
+		rewind: { label: 'Rewind' },
+		jump_prev: { label: 'Jump to previous cue' },
+		jump_next: { label: 'Jump to next cue' },
+		jump_selected: { label: 'Jump to selected cue' },
+		select_prev: { label: 'Select previous cue' },
+		select_next: { label: 'Select next cue' },
+		goto_30: { label: 'Goto 30' },
+		goto_20: { label: 'Goto 20' },
+		goto_10: { label: 'Goto 10' },
+		play_select: { label: 'Play Selected Cue' },
+		fullscreenToggle: { label: 'Toggle Fullscreen' },
+		fullscreenOn: { label: 'Fullscreen On' },
+		fullscreenOff: { label: 'Fullscreen Off' },
+		plLoopToggle: { label: 'Toggle Playlist Loop' },
+		plLoopOn: { label: 'Playlist Loop On' },
+		plLoopOff: { label: 'Playlist Loop Off' },
+		plTransToggle: { label: 'Toggle Playlist Transition on Play' },
+		plTransOff: { label: 'Transition on Play Off' },
+		plTransOn: { label: 'Transition on Play On' },
+		resendOSCFeedback: { label: 'Resend OSC feedback' },
+		jump_cue: {
 			label: 'Jump to specific cue',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'jumpCueName':     {
+		jumpCueName: {
 			label: 'Jump to cue with name',
-			options: [{
-				type: 'textinput',
-				label: 'Cue Name',
-				id: 'string'
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue Name',
+					id: 'string',
+				},
+			],
 		},
-		'select_cue':     {
+		select_cue: {
 			label: 'Select Cue',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'play_cue':     {
+		play_cue: {
 			label: 'Play Cue',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'playCueName':     {
+		playCueName: {
 			label: 'Play cue with name',
-			options: [{
-				type: 'textinput',
-				label: 'Cue Name',
-				id: 'string'
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue Name',
+					id: 'string',
+				},
+			],
 		},
-		'audioOn':     {
+		audioOn: {
 			label: 'Audio On',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'audioOff':     {
+		audioOff: {
 			label: 'Audio On',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'toggleAudio':     {
+		toggleAudio: {
 			label: 'Toggle Audio',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'toggleFadeIn':     {
+		toggleFadeIn: {
 			label: 'Toggle Fade In',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'fadeInOn':     {
+		fadeInOn: {
 			label: 'Fade In On',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'fadeInOff':     {
+		fadeInOff: {
 			label: 'Fade In Off',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'toggleFadeOut':     {
+		toggleFadeOut: {
 			label: 'Toggle Fade Out',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'fadeOutOn':     {
+		fadeOutOn: {
 			label: 'Fade Out On',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'fadeOutOff':     {
+		fadeOutOff: {
 			label: 'Fade Out Off',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'toggleLoop':     {
+		toggleLoop: {
 			label: 'Toggle Loop',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'loopOn':     {
+		loopOn: {
 			label: 'Loop On',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'loopOff':     {
+		loopOff: {
 			label: 'Loop Off',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'togglePauseAtBeginning':     {
+		togglePauseAtBeginning: {
 			label: 'Toggle Pause At Beginning',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'pauseAtBeginningOn':     {
+		pauseAtBeginningOn: {
 			label: 'Pause At Beginning On',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'pauseAtBeginningOff':     {
+		pauseAtBeginningOff: {
 			label: 'Pause At Beginning Off',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'togglePauseAtEnd':     {
+		togglePauseAtEnd: {
 			label: 'Toggle Pause At End',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'pauseAtEndOn':     {
+		pauseAtEndOn: {
 			label: 'Pause At End On',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'pauseAtEndOff':     {
+		pauseAtEndOff: {
 			label: 'Pause At End Off',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'toggleTransition':     {
+		toggleTransition: {
 			label: 'Toggle Transition',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'transitionOn':     {
+		transitionOn: {
 			label: 'Transition On',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'transitionOff':     {
+		transitionOff: {
 			label: 'Transition Off',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'toggleVideoFx':     {
+		toggleVideoFx: {
 			label: 'Toggle VideoFx',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'videoFxOn':     {
+		videoFxOn: {
 			label: 'VideoFx On',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-		'videoFxOff':     {
+		videoFxOff: {
 			label: 'VideoFx Off',
-			options: [{
-				type: 'textinput',
-				label: 'Cue number',
-				id: 'cuenumber',
-				default: 'current',
-			}]
+			options: [
+				{
+					type: 'textinput',
+					label: 'Cue number',
+					id: 'cuenumber',
+					default: 'current',
+				},
+			],
 		},
-	});
+	})
 }
 
-instance.prototype.sendNoArg = function(str,) {
-	var self = this;
-	self.system.emit('osc_send', self.config.host, 51000, str, []);
-	debug('Command =',str)
-};
+instance.prototype.sendNoArg = function (str) {
+	var self = this
+	self.system.emit('osc_send', self.config.host, 51000, str, [])
+	debug('Command =', str)
+}
 
-instance.prototype.sendArg = function(str,str2) {
-	var self = this;
-	self.system.emit('osc_send', self.config.host, 51000, str, [str2]);
-	debug('Command =',str,str2)
-};
+instance.prototype.sendArg = function (str, str2) {
+	var self = this
+	self.system.emit('osc_send', self.config.host, 51000, str, [str2])
+	debug('Command =', str, str2)
+}
 
-instance.prototype.action = function(action) {
-	var self = this;
-	var cmd;
-	var arg;
-	var opt = action.options;
+instance.prototype.action = function (action) {
+	var self = this
+	var cmd
+	var arg
+	var opt = action.options
 
-	switch(action.action){
-
+	switch (action.action) {
 		case 'play':
-			cmd = '/mitti/play';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/play'
+			self.sendNoArg(cmd)
+			break
 
 		case 'stop':
-			cmd = '/mitti/stop';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/stop'
+			self.sendNoArg(cmd)
+			break
 
 		case 'panic':
-			cmd = '/mitti/panic';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/panic'
+			self.sendNoArg(cmd)
+			break
 
 		case 'rewind':
-			cmd = '/mitti/rewind';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/rewind'
+			self.sendNoArg(cmd)
+			break
 
 		case 'jump_prev':
-			cmd = '/mitti/jumpToPrevCue';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/jumpToPrevCue'
+			self.sendNoArg(cmd)
+			break
 
 		case 'jump_next':
-			cmd = '/mitti/jumpToNextCue';
-			self.sendNoArg(cmd);
-			break;
-			
+			cmd = '/mitti/jumpToNextCue'
+			self.sendNoArg(cmd)
+			break
+
 		case 'jump_selected':
-			cmd = '/mitti/jumpToSelectedCue';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/jumpToSelectedCue'
+			self.sendNoArg(cmd)
+			break
 
 		case 'select_prev':
-			cmd = '/mitti/selectPrevCue';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/selectPrevCue'
+			self.sendNoArg(cmd)
+			break
 
 		case 'select_next':
-			cmd = '/mitti/selectNextCue';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/selectNextCue'
+			self.sendNoArg(cmd)
+			break
 
 		case 'goto_30':
-			cmd = '/mitti/goto30';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/goto30'
+			self.sendNoArg(cmd)
+			break
 
 		case 'goto_20':
-			cmd = '/mitti/goto20';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/goto20'
+			self.sendNoArg(cmd)
+			break
 
 		case 'goto_10':
-			cmd = '/mitti/goto10';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/goto10'
+			self.sendNoArg(cmd)
+			break
 
 		case 'toggle_play':
-			cmd = '/mitti/togglePlay';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/togglePlay'
+			self.sendNoArg(cmd)
+			break
 
 		case 'play_select':
-			cmd = '/mitti/playSelectedCue';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/playSelectedCue'
+			self.sendNoArg(cmd)
+			break
 
 		case 'locate':
-			cmd = '/mitti/locate';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/locate'
+			self.sendNoArg(cmd)
+			break
 
 		case 'jump_cue':
-			cmd = '/mitti/'+ opt.cuenumber + '/jump';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/jump'
+			self.sendNoArg(cmd)
+			break
 
 		case 'select_cue':
-			cmd = '/mitti/'+ opt.cuenumber + '/select';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/select'
+			self.sendNoArg(cmd)
+			break
 
 		case 'play_cue':
-			cmd = '/mitti/'+ opt.cuenumber + '/play';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/play'
+			self.sendNoArg(cmd)
+			break
 
 		case 'playCueName':
 			arg = {
-						type: "s",
-						value: opt.string
-			};
-			cmd = '/mitti/playCueWithName';
-			self.sendArg(cmd,arg);
-			break;
+				type: 's',
+				value: opt.string,
+			}
+			cmd = '/mitti/playCueWithName'
+			self.sendArg(cmd, arg)
+			break
 
 		case 'fullscreenOn':
-			cmd = '/mitti/fullscreenOn';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/fullscreenOn'
+			self.sendNoArg(cmd)
+			break
 
 		case 'fullscreenOff':
-			cmd = '/mitti/fullscreenOff';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/fullscreenOff'
+			self.sendNoArg(cmd)
+			break
 
 		case 'fullscreenToggle':
-			cmd = '/mitti/toggleFullscreen';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/toggleFullscreen'
+			self.sendNoArg(cmd)
+			break
 
 		case 'plLoopToggle':
-			cmd = '/mitti/toggleLoop';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/toggleLoop'
+			self.sendNoArg(cmd)
+			break
 
 		case 'plLoopOn':
-			cmd = '/mitti/loopOn';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/loopOn'
+			self.sendNoArg(cmd)
+			break
 
 		case 'plLoopOff':
-			cmd = '/mitti/loopOff';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/loopOff'
+			self.sendNoArg(cmd)
+			break
 
 		case 'plTransToggle':
-			cmd = '/mitti/toggleTransitionOnPlay';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/toggleTransitionOnPlay'
+			self.sendNoArg(cmd)
+			break
 
 		case 'plTransOff':
-			cmd = '/mitti/transitionOnPlayOff';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/transitionOnPlayOff'
+			self.sendNoArg(cmd)
+			break
 
 		case 'plTransOn':
-			cmd = '/mitti/transitionOnPlayOn';
-			self.sendNoArg(cmd);
-			break;
-			
+			cmd = '/mitti/transitionOnPlayOn'
+			self.sendNoArg(cmd)
+			break
+
 		case 'resendOSCFeedback':
-			cmd = '/mitti/resendOSCFeedback';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/resendOSCFeedback'
+			self.sendNoArg(cmd)
+			break
 
 		case 'jumpCueName':
 			arg = {
-						type: "s",
-						value: opt.string
-			};
-			cmd = '/mitti/jumpToCueWithName';
-			self.sendArg(cmd,arg);
-			break;
+				type: 's',
+				value: opt.string,
+			}
+			cmd = '/mitti/jumpToCueWithName'
+			self.sendArg(cmd, arg)
+			break
 
 		case 'toggleAudio':
-			cmd = '/mitti/'+ opt.cuenumber + '/toggleAudio';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/toggleAudio'
+			self.sendNoArg(cmd)
+			break
 
 		case 'audioOn':
-			cmd = '/mitti/'+ opt.cuenumber + '/audioOn';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/audioOn'
+			self.sendNoArg(cmd)
+			break
 
 		case 'audioOff':
-			cmd = '/mitti/'+ opt.cuenumber + '/audioOff';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/audioOff'
+			self.sendNoArg(cmd)
+			break
 
 		case 'toggleFadeIn':
-			cmd = '/mitti/'+ opt.cuenumber + '/toggleFadeIn';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/toggleFadeIn'
+			self.sendNoArg(cmd)
+			break
 
 		case 'fadeInOn':
-			cmd = '/mitti/'+ opt.cuenumber + '/fadeInOn';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/fadeInOn'
+			self.sendNoArg(cmd)
+			break
 
 		case 'fadeInOff':
-			cmd = '/mitti/'+ opt.cuenumber + '/fadeInOff';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/fadeInOff'
+			self.sendNoArg(cmd)
+			break
 
 		case 'toggleFadeOut':
-			cmd = '/mitti/'+ opt.cuenumber + '/toggleFadeOut';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/toggleFadeOut'
+			self.sendNoArg(cmd)
+			break
 
 		case 'fadeOutOn':
-			cmd = '/mitti/'+ opt.cuenumber + '/fadeOutOn';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/fadeOutOn'
+			self.sendNoArg(cmd)
+			break
 
 		case 'fadeOutOff':
-			cmd = '/mitti/'+ opt.cuenumber + '/fadeOutOff';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/fadeOutOff'
+			self.sendNoArg(cmd)
+			break
 
 		case 'toggleLoop':
-			cmd = '/mitti/'+ opt.cuenumber + '/toggleLoop';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/toggleLoop'
+			self.sendNoArg(cmd)
+			break
 
 		case 'loopOn':
-			cmd = '/mitti/'+ opt.cuenumber + '/loopOn';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/loopOn'
+			self.sendNoArg(cmd)
+			break
 
 		case 'loopOff':
-			cmd = '/mitti/'+ opt.cuenumber + '/loopOff';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/loopOff'
+			self.sendNoArg(cmd)
+			break
 
 		case 'togglePauseAtBeginning':
-			cmd = '/mitti/'+ opt.cuenumber + '/togglePauseAtBeginning';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/togglePauseAtBeginning'
+			self.sendNoArg(cmd)
+			break
 
 		case 'pauseAtBeginningOn':
-			cmd = '/mitti/'+ opt.cuenumber + '/pauseAtBeginningOn';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/pauseAtBeginningOn'
+			self.sendNoArg(cmd)
+			break
 
 		case 'pauseAtBeginningOff':
-			cmd = '/mitti/'+ opt.cuenumber + '/pauseAtBeginningOff';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/pauseAtBeginningOff'
+			self.sendNoArg(cmd)
+			break
 
 		case 'togglePauseAtEnd':
-			cmd = '/mitti/'+ opt.cuenumber + '/togglePauseAtEnd';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/togglePauseAtEnd'
+			self.sendNoArg(cmd)
+			break
 
 		case 'pauseAtEndOn':
-			cmd = '/mitti/'+ opt.cuenumber + '/pauseAtEndOn';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/pauseAtEndOn'
+			self.sendNoArg(cmd)
+			break
 
 		case 'pauseAtEndOff':
-			cmd = '/mitti/'+ opt.cuenumber + '/pauseAtEndOff';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/pauseAtEndOff'
+			self.sendNoArg(cmd)
+			break
 
 		case 'toggleTransition':
-			cmd = '/mitti/'+ opt.cuenumber + '/toggleTransition';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/toggleTransition'
+			self.sendNoArg(cmd)
+			break
 
 		case 'transitionOn':
-			cmd = '/mitti/'+ opt.cuenumber + '/transitionOn';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/transitionOn'
+			self.sendNoArg(cmd)
+			break
 
 		case 'transitionOff':
-			cmd = '/mitti/'+ opt.cuenumber + '/transitionOff';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/transitionOff'
+			self.sendNoArg(cmd)
+			break
 
 		case 'toggleVideoFx':
-			cmd = '/mitti/'+ opt.cuenumber + '/toggleVideoFx';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/toggleVideoFx'
+			self.sendNoArg(cmd)
+			break
 
 		case 'videoFxOn':
-			cmd = '/mitti/'+ opt.cuenumber + '/videoFxOn';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/videoFxOn'
+			self.sendNoArg(cmd)
+			break
 
 		case 'videoFxOff':
-			cmd = '/mitti/'+ opt.cuenumber + '/videoFxOff';
-			self.sendNoArg(cmd);
-			break;
+			cmd = '/mitti/' + opt.cuenumber + '/videoFxOff'
+			self.sendNoArg(cmd)
+			break
 	}
-};
+}
 
 instance.prototype.init_osc = function () {
-	var self = this;
-	self.ready = true;
+	var self = this
+	self.ready = true
 
 	if (self.listener) {
-		self.listener.close();
+		self.listener.close()
 	}
 
 	self.listener = new OSC.UDPPort({
-		localAddress: "0.0.0.0",
+		localAddress: '0.0.0.0',
 		localPort: self.config.feedbackPort,
 		broadcast: true,
-		metadata: true
-	});
+		metadata: true,
+	})
 
-	self.listener.open();
+	self.listener.open()
 
-	self.listener.on("ready", function () {
-		self.ready = true;
-		self.system.emit('osc_send', self.config.host, 51000, '/mitti/resendOSCFeedback', []);
-	});
-	self.listener.on("error", function (err) {
-	if (err.code == "EADDRINUSE") {
-		self.log('error', "Error: Selected port in use." + err.message);
-	}
-	});
+	self.listener.on('ready', function () {
+		self.ready = true
+		self.system.emit('osc_send', self.config.host, 51000, '/mitti/resendOSCFeedback', [])
+	})
+	self.listener.on('error', function (err) {
+		if (err.code == 'EADDRINUSE') {
+			self.log('error', 'Error: Selected port in use.' + err.message)
+		}
+	})
 
-	self.listener.on("message", function (message) {
-		var a = message.address.split("/");
+	self.listener.on('message', function (message) {
+		var a = message.address.split('/')
 		if (message.address === '/mitti/currentCueName') {
 			if (message.args.length > 0) {
-				var currentCueName = message.args[0].value;
-				if (typeof currentCueName === "string") {
-					if (currentCueName === "-") {
-						currentCueName = 'None';
+				var currentCueName = message.args[0].value
+				if (typeof currentCueName === 'string') {
+					if (currentCueName === '-') {
+						currentCueName = 'None'
 					}
-					self.setVariable('currentCueName', currentCueName);
+					self.setVariable('currentCueName', currentCueName)
 				}
 			}
 		} else if (message.address === '/mitti/previousCueName') {
 			if (message.args.length > 0) {
-				var previousCueName = message.args[0].value;
-				if (typeof previousCueName === "string") {
-					if (previousCueName === "-") {
-						previousCueName = 'None';
+				var previousCueName = message.args[0].value
+				if (typeof previousCueName === 'string') {
+					if (previousCueName === '-') {
+						previousCueName = 'None'
 					}
-					self.setVariable('previousCueName', previousCueName);
+					self.setVariable('previousCueName', previousCueName)
 				}
 			}
 		} else if (message.address === '/mitti/nextCueName') {
 			if (message.args.length > 0) {
-				var nextCueName = message.args[0].value;
-				if (typeof nextCueName === "string") {
-					if (nextCueName === "-") {
-						nextCueName = 'None';
+				var nextCueName = message.args[0].value
+				if (typeof nextCueName === 'string') {
+					if (nextCueName === '-') {
+						nextCueName = 'None'
 					}
-					self.setVariable('nextCueName', nextCueName);
+					self.setVariable('nextCueName', nextCueName)
 				}
 			}
 		} else if (message.address === '/mitti/selectedCueName') {
 			if (message.args.length > 0) {
-				var selectedCueName = message.args[0].value;
-				if (typeof selectedCueName === "string") {
-					if (selectedCueName === "-") {
-						selectedCueName = 'None';
+				var selectedCueName = message.args[0].value
+				if (typeof selectedCueName === 'string') {
+					if (selectedCueName === '-') {
+						selectedCueName = 'None'
 					}
-					self.setVariable('selectedCueName', selectedCueName);
+					self.setVariable('selectedCueName', selectedCueName)
 				}
 			}
 		} else if (message.address === '/mitti/cueTimeLeft') {
@@ -1685,14 +1736,14 @@ instance.prototype.init_osc = function () {
 				let cueTimeSS = cueTimeSplit.groups.ss
 				let cueTimeHHMMSS = `-${cueTimeHH == '00' ? '' : cueTimeHH + ':'}${cueTimeMM}:${cueTimeSS}`
 
-				self.setVariable('cueTimeLeft', cueTimeHHMMSS);
-				self.setVariable('cueTimeLeft_h', cueTimeHH);
-				self.setVariable('cueTimeLeft_m', cueTimeMM);
-				self.setVariable('cueTimeLeft_s', cueTimeSS);
+				self.setVariable('cueTimeLeft', cueTimeHHMMSS)
+				self.setVariable('cueTimeLeft_h', cueTimeHH)
+				self.setVariable('cueTimeLeft_m', cueTimeMM)
+				self.setVariable('cueTimeLeft_s', cueTimeSS)
 			}
 		} else if (message.address === '/mitti/currentCueTRT') {
 			if (message.args.length > 0) {
-				var currentCueTRT = message.args[0].value;
+				var currentCueTRT = message.args[0].value
 				let cueTimeSplit = currentCueTRT.match(/^(?<hh>\d\d):(?<mm>\d\d):(?<ss>\d\d)/i)
 
 				let cueTimeHH = cueTimeSplit.groups.hh
@@ -1700,98 +1751,98 @@ instance.prototype.init_osc = function () {
 				let cueTimeSS = cueTimeSplit.groups.ss
 				let cueTimeHHMMSS = `${cueTimeHH == '00' ? '' : cueTimeHH + ':'}${cueTimeMM}:${cueTimeSS}`
 
-				self.setVariable('currentCueTRT', cueTimeHHMMSS);
+				self.setVariable('currentCueTRT', cueTimeHHMMSS)
 			}
 		} else if (message.address === '/mitti/togglePlay') {
 			if (message.args.length >= 0) {
-				var togglePlayStatus = message.args[0].value;
-				if (typeof togglePlayStatus === "number") {
+				var togglePlayStatus = message.args[0].value
+				if (typeof togglePlayStatus === 'number') {
 					if (togglePlayStatus === 0) {
-						self.playStatus = "Paused";
+						self.playStatus = 'Paused'
 					} else {
-						self.playStatus = "Playing";
+						self.playStatus = 'Playing'
 					}
-					self.setVariable('playStatus', self.playStatus);
-					self.checkFeedbacks('playStatus');
+					self.setVariable('playStatus', self.playStatus)
+					self.checkFeedbacks('playStatus')
 				}
 			}
 		}
-	});
+	})
 }
 
 instance.prototype.init_variables = function () {
-	var self = this;
-	var variables = [];
+	var self = this
+	var variables = []
 
-	var currentCueName = 'None';
-	var previousCueName = 'None';
-	var nextCueName = 'None';
-	var selectedCueName = 'None';
-	var cueTimeLeft = '-00:00:00';
-	var currentCueTRT = '00:00:00';
-	var playStatus = 'Paused';
+	var currentCueName = 'None'
+	var previousCueName = 'None'
+	var nextCueName = 'None'
+	var selectedCueName = 'None'
+	var cueTimeLeft = '-00:00:00'
+	var currentCueTRT = '00:00:00'
+	var playStatus = 'Paused'
 
 	variables.push({
 		label: 'Currently playing cue',
-		name:  'currentCueName'
-	});
-	self.setVariable('currentCueName', currentCueName);
+		name: 'currentCueName',
+	})
+	self.setVariable('currentCueName', currentCueName)
 
 	variables.push({
 		label: 'Previous cue in playlist',
-		name:  'previousCueName'
-	});
-	self.setVariable('previousCueName', previousCueName);
+		name: 'previousCueName',
+	})
+	self.setVariable('previousCueName', previousCueName)
 
 	variables.push({
 		label: 'Next cue in playlist',
-		name:  'nextCueName'
-	});
-	self.setVariable('nextCueName', nextCueName);
+		name: 'nextCueName',
+	})
+	self.setVariable('nextCueName', nextCueName)
 
 	variables.push({
 		label: 'Selected cue in playlist',
-		name:  'selectedCueName'
-	});
-	self.setVariable('selectedCueName', selectedCueName);
+		name: 'selectedCueName',
+	})
+	self.setVariable('selectedCueName', selectedCueName)
 
 	variables.push({
 		label: 'Play/ Pause Status',
-		name:  'playStatus'
-	});
-	self.setVariable('playStatus', playStatus);
+		name: 'playStatus',
+	})
+	self.setVariable('playStatus', playStatus)
 
 	variables.push({
 		label: 'Time remaining for current cue (-HH:MM:SS)',
-		name:  'cueTimeLeft'
-	});
-	self.setVariable('cueTimeLeft', cueTimeLeft);
-	
+		name: 'cueTimeLeft',
+	})
+	self.setVariable('cueTimeLeft', cueTimeLeft)
+
 	variables.push({
 		label: 'Time remaining for current cue (hours)',
-		name:  'cueTimeLeft_h'
-	});
-	self.setVariable('cueTimeLeftHH', '00');
+		name: 'cueTimeLeft_h',
+	})
+	self.setVariable('cueTimeLeftHH', '00')
 
 	variables.push({
 		label: 'Time remaining for current cue (minutes)',
-		name:  'cueTimeLeft_m'
-	});
-	self.setVariable('cueTimeLeftMM', '00');
+		name: 'cueTimeLeft_m',
+	})
+	self.setVariable('cueTimeLeftMM', '00')
 
 	variables.push({
 		label: 'Time remaining for current cue (seconds)',
-		name:  'cueTimeLeft_s'
-	});
-	self.setVariable('cueTimeLeft_s', '00');
+		name: 'cueTimeLeft_s',
+	})
+	self.setVariable('cueTimeLeft_s', '00')
 
 	variables.push({
 		label: 'Total run time (TRT) for current cue',
-		name:  'currentCueTRT'
-	});
-	self.setVariable('currentCueTRT', currentCueTRT);
+		name: 'currentCueTRT',
+	})
+	self.setVariable('currentCueTRT', currentCueTRT)
 
-	self.setVariableDefinitions(variables);
+	self.setVariableDefinitions(variables)
 }
 
 instance.prototype.init_feedbacks = function () {
@@ -1802,9 +1853,9 @@ instance.prototype.init_feedbacks = function () {
 		type: 'boolean',
 		label: 'Change colors based on Play/Pause status',
 		description: 'Change colors based on Play/Pause status',
-		style : {
+		style: {
 			color: self.rgb(255, 255, 255),
-			bgcolor: self.rgb(0, 200, 0)
+			bgcolor: self.rgb(0, 200, 0),
 		},
 		options: [
 			{
@@ -1814,10 +1865,10 @@ instance.prototype.init_feedbacks = function () {
 				default: 'Playing',
 				choices: [
 					{ id: 'Playing', label: 'Playing' },
-					{ id: 'Paused', label: 'Paused' }
-				]
-			}
-		]
+					{ id: 'Paused', label: 'Paused' },
+				],
+			},
+		],
 	}
 	self.setFeedbackDefinitions(feedbacks)
 }
@@ -1834,5 +1885,5 @@ instance.prototype.feedback = function (feedback, bank) {
 	return false
 }
 
-instance_skel.extendedBy(instance);
-exports = module.exports = instance;
+instance_skel.extendedBy(instance)
+exports = module.exports = instance

--- a/mitti.js
+++ b/mitti.js
@@ -59,6 +59,7 @@ instance.prototype.config_fields = function () {
 			width: 5,
 			tooltip: 'The port designated for Feedback in the OSC/UDP Controls tab in Mitti',
 			default: 51001,
+			regex: self.REGEX_PORT,
 		},
 	]
 }

--- a/mitti.js
+++ b/mitti.js
@@ -2177,13 +2177,13 @@ instance.prototype.init_variables = function () {
 		label: 'Time remaining for current cue (hours)',
 		name: 'cueTimeLeft_h',
 	})
-	self.setVariable('cueTimeLeftHH', '00')
+	self.setVariable('cueTimeLeft_h', '00')
 
 	variables.push({
 		label: 'Time remaining for current cue (minutes)',
 		name: 'cueTimeLeft_m',
 	})
-	self.setVariable('cueTimeLeftMM', '00')
+	self.setVariable('cueTimeLeft_m', '00')
 
 	variables.push({
 		label: 'Time remaining for current cue (seconds)',

--- a/mitti.js
+++ b/mitti.js
@@ -480,14 +480,10 @@ instance.prototype.init_presets = function () {
 			},
 			actions: [
 				{
-					action: 'jumpCueName',
+					action: 'playCueName',
 					options: {
 						string: '',
 					},
-				},
-				{
-					action: 'play',
-					delay: '100',
 				},
 			],
 		},

--- a/mitti.js
+++ b/mitti.js
@@ -69,7 +69,7 @@ instance.prototype.destroy = function() {
 	if (self.listener) {
 		self.listener.close();
 	}
-	debug("destory", self.id);
+	debug("destroy", self.id);
 };
 
 instance.prototype.init_presets = function () {
@@ -1677,25 +1677,30 @@ instance.prototype.init_osc = function () {
 			}
 		} else if (message.address === '/mitti/cueTimeLeft') {
 			if (message.args.length > 0) {
-				var cueTimeLeft = message.args[0].value;
-				if (typeof cueTimeLeft === "string") {
-					if (cueTimeLeft.startsWith('-00', 0)) {
-						self.setVariable('cueTimeLeft', '-' + cueTimeLeft.substr(4, 5));
-					} else {
-						self.setVariable('cueTimeLeft', cueTimeLeft.substr(0, 9));
-					}
-				}
+				var cueTimeLeft = message.args[0].value
+				let cueTimeSplit = cueTimeLeft.match(/^-(?<hh>\d\d):(?<mm>\d\d):(?<ss>\d\d)/i)
+
+				let cueTimeHH = cueTimeSplit.groups.hh
+				let cueTimeMM = cueTimeSplit.groups.mm
+				let cueTimeSS = cueTimeSplit.groups.ss
+				let cueTimeHHMMSS = `-${cueTimeHH == '00' ? '' : cueTimeHH + ':'}${cueTimeMM}:${cueTimeSS}`
+
+				self.setVariable('cueTimeLeft', cueTimeHHMMSS);
+				self.setVariable('cueTimeLeft_h', cueTimeHH);
+				self.setVariable('cueTimeLeft_m', cueTimeMM);
+				self.setVariable('cueTimeLeft_s', cueTimeSS);
 			}
 		} else if (message.address === '/mitti/currentCueTRT') {
 			if (message.args.length > 0) {
 				var currentCueTRT = message.args[0].value;
-				if (typeof currentCueTRT === "string") {
-					if (currentCueTRT.startsWith('00', 0)) {
-						self.setVariable('currentCueTRT', currentCueTRT.substr(3, 5));
-					} else {
-						self.setVariable('currentCueTRT', currentCueTRT.substr(0, 8));
-					}
-				}
+				let cueTimeSplit = currentCueTRT.match(/^(?<hh>\d\d):(?<mm>\d\d):(?<ss>\d\d)/i)
+
+				let cueTimeHH = cueTimeSplit.groups.hh
+				let cueTimeMM = cueTimeSplit.groups.mm
+				let cueTimeSS = cueTimeSplit.groups.ss
+				let cueTimeHHMMSS = `${cueTimeHH == '00' ? '' : cueTimeHH + ':'}${cueTimeMM}:${cueTimeSS}`
+
+				self.setVariable('currentCueTRT', cueTimeHHMMSS);
 			}
 		} else if (message.address === '/mitti/togglePlay') {
 			if (message.args.length >= 0) {
@@ -1749,24 +1754,42 @@ instance.prototype.init_variables = function () {
 		name:  'selectedCueName'
 	});
 	self.setVariable('selectedCueName', selectedCueName);
-	
-	variables.push({
-		label: 'Time remaining for current cue',
-		name:  'cueTimeLeft'
-	});
-	self.setVariable('cueTimeLeft', cueTimeLeft);
-	
-	variables.push({
-		label: 'Total run time (TRT) for current cue',
-		name:  'currentCueTRT'
-	});
-	self.setVariable('currentCueTRT', currentCueTRT);
 
 	variables.push({
 		label: 'Play/ Pause Status',
 		name:  'playStatus'
 	});
 	self.setVariable('playStatus', playStatus);
+
+	variables.push({
+		label: 'Time remaining for current cue (-HH:MM:SS)',
+		name:  'cueTimeLeft'
+	});
+	self.setVariable('cueTimeLeft', cueTimeLeft);
+	
+	variables.push({
+		label: 'Time remaining for current cue (hours)',
+		name:  'cueTimeLeft_h'
+	});
+	self.setVariable('cueTimeLeftHH', '00');
+
+	variables.push({
+		label: 'Time remaining for current cue (minutes)',
+		name:  'cueTimeLeft_m'
+	});
+	self.setVariable('cueTimeLeftMM', '00');
+
+	variables.push({
+		label: 'Time remaining for current cue (seconds)',
+		name:  'cueTimeLeft_s'
+	});
+	self.setVariable('cueTimeLeft_s', '00');
+
+	variables.push({
+		label: 'Total run time (TRT) for current cue',
+		name:  'currentCueTRT'
+	});
+	self.setVariable('currentCueTRT', currentCueTRT);
 
 	self.setVariableDefinitions(variables);
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"mitti"
 	],
-	"version": "1.0.8",
+	"version": "1.0.9",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Software",
@@ -18,5 +18,8 @@
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},
 	"author": "Per Røine <per.roine@gmail.com>",
+	"contributors": [
+		"Bryce Seifert"
+	],
 	"license": "MIT"
 }


### PR DESCRIPTION
**New variables** (closes https://github.com/bitfocus/companion-module-imimot-mitti/issues/16)
- cueTimeLeft_h
- cueTimeLeft_m
- cueTimeLeft_s 

**New actions**
-  Cue Scale
- Cue Position
- Cue Crop
- Cue Rotation
- Cue Hue
- Cue Saturation
- Cue Vibrance
- Cue Brightness
- Cue Contrast
- Cue Opacity
- Cue Volume

**Minor**
- Can now use cue ID (Mitti 2) anywhere a cue number was previously used