### PR TITLE
feat: bonjour discovery + OSC feedback status

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -26,5 +26,11 @@
 	},
 	"manufacturer": "Imimot",
 	"products": ["Mitti"],
-	"keywords": ["Software", "Video"]
+	"keywords": ["Software", "Video"],
+	"bonjourQueries": {
+		"bonjourHost": {
+			"type": "osc",
+			"protocol": "udp"
+		}
+	}
 }

--- a/index.js
+++ b/index.js
@@ -139,7 +139,6 @@ class MittiInstance extends InstanceBase {
 		const ipRegex = /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
 
 		if (this.config.bonjourHost) {
-			console.log('Bonjour Host:', this.config.bonjourHost)
 			const [ip, rawPort] = this.config.bonjourHost.split(':')
 			const port = Number(rawPort)
 			if (ip.match(ipRegex) && !isNaN(port)) {
@@ -267,7 +266,6 @@ class MittiInstance extends InstanceBase {
 
 	startTestService() {
 		this.stopTestService()
-		console.log('Starting Connection Test')
 		this.log('debug', 'Starting Connection Test')
 		this.testConnection()
 	}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"mitti"
 	],
-	"version": "3.7.2",
+	"version": "3.8.0",
 	"main": "index.js",
 	"type": "module",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 	},
 	"dependencies": {
 		"@companion-module/base": "~1.11.3",
+		"@homebridge/ciao": "^1.3.1",
 		"osc": "^2.4.5"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	},
 	"devDependencies": {
 		"@companion-module/tools": "^2.1.1",
-		"eslint": "^9.17.0",
+		"eslint": "^9.18.0",
 		"prettier": "^3.4.2"
 	},
 	"engines": {

--- a/upgrades.js
+++ b/upgrades.js
@@ -22,4 +22,20 @@ export default [
 
 		return changes
 	},
+	function v3_8_0(context, props) {
+		let changes = {
+			updatedConfig: null,
+			updatedActions: [],
+			updatedFeedbacks: [],
+		}
+		if (props.config) {
+			let config = props.config
+			if (config.feedbackAlert === undefined || config.feedbackAlert === null) {
+				config.feedbackAlert = false
+				changes.updatedConfig = config
+			}
+		}
+
+		return changes
+	},
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,6 +152,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@homebridge/ciao@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "@homebridge/ciao@npm:1.3.1"
+  dependencies:
+    debug: "npm:^4.3.6"
+    fast-deep-equal: "npm:^3.1.3"
+    source-map-support: "npm:^0.5.21"
+    tslib: "npm:^2.6.3"
+  bin:
+    ciao-bcs: lib/bonjour-conformance-testing.js
+  checksum: 10c0/439ce3f87f47f70c863dcae79b9896305b862317302e1949579d34d172e2c69db8146b6129013bcbf4c901847596f6ca1857a5a415f2b9f2cdc444cb38ce7690
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -1018,7 +1032,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.6":
   version: 4.4.0
   resolution: "debug@npm:4.4.0"
   dependencies:
@@ -1647,6 +1661,7 @@ __metadata:
   dependencies:
     "@companion-module/base": "npm:~1.11.3"
     "@companion-module/tools": "npm:^2.1.1"
+    "@homebridge/ciao": "npm:^1.3.1"
     eslint: "npm:^9.17.0"
     osc: "npm:^2.4.5"
     prettier: "npm:^3.4.2"
@@ -2675,7 +2690,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:~0.5.20":
+"source-map-support@npm:^0.5.21, source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
   dependencies:
@@ -2847,7 +2862,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tslib@npm:^2.6.2, tslib@npm:^2.8.1":
+"tslib@npm:^2.6.2, tslib@npm:^2.6.3, tslib@npm:^2.8.1":
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,12 +103,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/core@npm:^0.9.0":
-  version: 0.9.1
-  resolution: "@eslint/core@npm:0.9.1"
+"@eslint/core@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@eslint/core@npm:0.10.0"
   dependencies:
     "@types/json-schema": "npm:^7.0.15"
-  checksum: 10c0/638104b1b5833a9bbf2329f0c0ddf322e4d6c0410b149477e02cd2b78c04722be90c14b91b8ccdef0d63a2404dff72a17b6b412ce489ea429ae6a8fcb8abff28
+  checksum: 10c0/074018075079b3ed1f14fab9d116f11a8824cdfae3e822badf7ad546962fafe717a31e61459bad8cc59cf7070dc413ea9064ddb75c114f05b05921029cde0a64
   languageName: node
   linkType: hard
 
@@ -129,7 +129,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.17.0, @eslint/js@npm:^9.17.0":
+"@eslint/js@npm:9.18.0":
+  version: 9.18.0
+  resolution: "@eslint/js@npm:9.18.0"
+  checksum: 10c0/3938344c5ac7feef4b73fcb30f3c3e753570cea74c24904bb5d07e9c42fcd34fcbc40f545b081356a299e11f360c9c274b348c05fb0113fc3d492e5175eee140
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:^9.17.0":
   version: 9.17.0
   resolution: "@eslint/js@npm:9.17.0"
   checksum: 10c0/a0fda8657a01c60aa540f95397754267ba640ffb126e011b97fd65c322a94969d161beeaef57c1441c495da2f31167c34bd38209f7c146c7225072378c3a933d
@@ -143,12 +150,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/plugin-kit@npm:^0.2.3":
-  version: 0.2.4
-  resolution: "@eslint/plugin-kit@npm:0.2.4"
+"@eslint/plugin-kit@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "@eslint/plugin-kit@npm:0.2.5"
   dependencies:
+    "@eslint/core": "npm:^0.10.0"
     levn: "npm:^0.4.1"
-  checksum: 10c0/1bcfc0a30b1df891047c1d8b3707833bded12a057ba01757a2a8591fdc8d8fe0dbb8d51d4b0b61b2af4ca1d363057abd7d2fb4799f1706b105734f4d3fa0dbf1
+  checksum: 10c0/ba9832b8409af618cf61791805fe201dd62f3c82c783adfcec0f5cd391e68b40beaecb47b9a3209e926dbcab65135f410cae405b69a559197795793399f61176
   languageName: node
   linkType: hard
 
@@ -1275,17 +1283,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.17.0":
-  version: 9.17.0
-  resolution: "eslint@npm:9.17.0"
+"eslint@npm:^9.18.0":
+  version: 9.18.0
+  resolution: "eslint@npm:9.18.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
     "@eslint/config-array": "npm:^0.19.0"
-    "@eslint/core": "npm:^0.9.0"
+    "@eslint/core": "npm:^0.10.0"
     "@eslint/eslintrc": "npm:^3.2.0"
-    "@eslint/js": "npm:9.17.0"
-    "@eslint/plugin-kit": "npm:^0.2.3"
+    "@eslint/js": "npm:9.18.0"
+    "@eslint/plugin-kit": "npm:^0.2.5"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@humanwhocodes/retry": "npm:^0.4.1"
@@ -1320,7 +1328,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/9edd8dd782b4ae2eb00a158ed4708194835d4494d75545fa63a51f020ed17f865c49b4ae1914a2ecbc7fdb262bd8059e811aeef9f0bae63dced9d3293be1bbdd
+  checksum: 10c0/7f592ad228b9bd627a24870fdc875bacdab7bf535d4b67316c4cb791e90d0125130a74769f3c407b0c4b7027b3082ef33864a63ee1024552a60a17db60493f15
   languageName: node
   linkType: hard
 
@@ -1662,7 +1670,7 @@ __metadata:
     "@companion-module/base": "npm:~1.11.3"
     "@companion-module/tools": "npm:^2.1.1"
     "@homebridge/ciao": "npm:^1.3.1"
-    eslint: "npm:^9.17.0"
+    eslint: "npm:^9.18.0"
     osc: "npm:^2.4.5"
     prettier: "npm:^3.4.2"
   languageName: unknown


### PR DESCRIPTION
New

- New config option to change module state to error if not receiving feedback. Requires Mitti  v2.2.8 and above (closes https://github.com/bitfocus/companion-module-imimot-mitti/issues/49)
- Adds bonjour discovery dropdown of possible mitti instances in module config
- Broadcast bonjour info from module to allow easy setup of module in Mitti OSC controls
